### PR TITLE
Force load dictionary as UTF8

### DIFF
--- a/eoparser.py
+++ b/eoparser.py
@@ -53,7 +53,7 @@ def to_lower(word: str) -> str:
         return res
 
 def read_as_set(path: str) -> set:
-        f = open(path)
+        f = open(path, encoding = "utf-8")
         s = set()
         for word in f:
                 word = word.replace(' ', '').replace('\t', '').replace('\n', '')


### PR DESCRIPTION
Fix for #1. Windows does not use UTF-8 by default.